### PR TITLE
fix: update GitHub links to correct repository URL

### DIFF
--- a/src/components/landing/CommunitySection.tsx
+++ b/src/components/landing/CommunitySection.tsx
@@ -12,7 +12,7 @@ const SOCIAL_LINKS = [
   {
     name: 'GitHub',
     icon: Github,
-    href: 'https://github.com/kitsunecube',
+    href: 'https://github.com/gisketch/kitsune-cube',
     description: 'Star the project',
     color: '#ffffff',
   },

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -22,7 +22,7 @@ const FOOTER_LINKS = {
 }
 
 const SOCIAL_LINKS = [
-  { name: 'GitHub', icon: Github, href: 'https://github.com/kitsunecube' },
+  { name: 'GitHub', icon: Github, href: 'https://github.com/gisketch/kitsune-cube' },
   { name: 'Discord', icon: MessageCircle, href: 'https://discord.gg/XPQr4wpQVg' },
   { name: 'Ko-fi', icon: Coffee, href: 'https://ko-fi.com/kitsunecube' },
 ]


### PR DESCRIPTION
Update GitHub links from kitsunecube to gisketch/kitsune-cube
in LandingFooter and CommunitySection components