### PR TITLE
fix: resolve gan-web-bluetooth vite import error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(import.meta.dirname, 'src'),
+      // Resolve gan-web-bluetooth to source files since dist may not be built
+      'gan-web-bluetooth': path.resolve(import.meta.dirname, 'node_modules/gan-web-bluetooth/src/index.ts'),
     },
   },
   worker: {


### PR DESCRIPTION
## Problem
When running `npm run dev`, Vite fails to resolve the `gan-web-bluetooth` package entry point. The error occurs because the package's `package.json` points to `dist/esm/index.mjs`, but the `dist` folder doesn't exist (likely because the package wasn't built or the build script uses Unix commands that don't work on Windows).

## Solution
Added a Vite alias in `vite.config.ts` to resolve `gan-web-bluetooth` directly to its TypeScript source files (`src/index.ts`). Vite can transpile TypeScript on the fly, so this allows the dev server to work without requiring the package to be pre-built.

## Changes
- Added alias in `vite.config.ts` to resolve `gan-web-bluetooth` to `node_modules/gan-web-bluetooth/src/index.ts`


Note: Tested on windows, will test on Unix based system later and update if necessery, please don't merge before testing on Unix based OS