### PR TITLE
chore: add .env files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
+.env
 .env.local
+.env*.local
 
 # Service account keys (sensitive!)
 scripts/service-account.json


### PR DESCRIPTION
## Problem
The `.env` file containing Firebase credentials is not excluded from git, which could lead to accidentally committing sensitive configuration.

## Changes
Updated `.gitignore` to exclude `.env`, `.env.local`, and `.env*.local` files to prevent accidentally committing Firebase credentials and other sensitive environment variables.